### PR TITLE
Add ruby support on arrays

### DIFF
--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -23,8 +23,9 @@ module ActiveRecord
         # for postgres:
         mod.predicate_builder.register_handler(ILIKE, ILIKE.arel_proc)
 
-        # NOTE: currently not using GenericOp for regexp
+        # NOTE: Probably want Regexp over REGEXP (e.g.: where(:name => /value/i))
         mod.predicate_builder.register_handler(Regexp, REGEXP.arel_proc)
+        mod.predicate_builder.register_handler(REGEXP, REGEXP.arel_proc)
       end
     end
   end

--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -30,3 +30,23 @@ module ActiveRecord
     end
   end
 end
+
+class Array
+  def where(options)
+    select do |rec|
+      options.all? do |name, value|
+        actual_val = rec.send(name)
+        case value
+        when Regexp
+          actual_val =~ value
+        when Array
+          value.include?(actual_val)
+        when ActiveRecord::HashOptions::GenericOp
+          value.call(actual_val)
+        else # NilClass, String, Integer
+          actual_val == value
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -14,17 +14,17 @@ module ActiveRecord
 
     def self.register_my_handler(mod)
       if mod < ActiveRecord::Base && mod.kind_of?(Class)
-        mod.predicate_builder.register_handler(GT, proc { |column, op| Arel::Nodes::GreaterThan.new(column, op.expression) })
-        mod.predicate_builder.register_handler(LT, proc { |column, op| Arel::Nodes::LessThan.new(column, op.expression) })
-        mod.predicate_builder.register_handler(GTE, proc { |column, op| Arel::Nodes::GreaterThanOrEqual.new(column, op.expression) })
-        mod.predicate_builder.register_handler(LTE, proc { |column, op| Arel::Nodes::LessThanOrEqual.new(column, op.expression) })
-        mod.predicate_builder.register_handler(LIKE, proc { |column, op| Arel::Nodes::Matches.new(column, Arel::Nodes.build_quoted(op.expression, column), nil, true) })
-        mod.predicate_builder.register_handler(NOT_LIKE, proc { |column, op| Arel::Nodes::DoesNotMatch.new(column, Arel::Nodes.build_quoted(op.expression, column), nil, true) })
+        mod.predicate_builder.register_handler(GT, GT.arel_proc)
+        mod.predicate_builder.register_handler(LT, LT.arel_proc)
+        mod.predicate_builder.register_handler(GTE, GTE.arel_proc)
+        mod.predicate_builder.register_handler(LTE, LTE.arel_proc)
+        mod.predicate_builder.register_handler(LIKE, LIKE.arel_proc)
+        mod.predicate_builder.register_handler(NOT_LIKE, NOT_LIKE.arel_proc)
         # for postgres:
-        mod.predicate_builder.register_handler(ILIKE, proc { |column, op| Arel::Nodes::Matches.new(column, Arel::Nodes.build_quoted(op.expression, column), nil, false) })
+        mod.predicate_builder.register_handler(ILIKE, ILIKE.arel_proc)
 
         # NOTE: currently not using GenericOp for regexp
-        mod.predicate_builder.register_handler(Regexp, proc { |column, op|  Arel::Nodes::Regexp.new(column, op, !!(op.options && Regexp::IGNORECASE))})
+        mod.predicate_builder.register_handler(Regexp, REGEXP.arel_proc)
       end
     end
   end

--- a/lib/active_record/hash_options/operators.rb
+++ b/lib/active_record/hash_options/operators.rb
@@ -2,13 +2,56 @@ module ActiveRecord
   module HashOptions
     GenericOp = Struct.new(:expression)
 
-    class GT < GenericOp; end
-    class LT < GenericOp; end
-    class GTE < GenericOp; end
-    class LTE < GenericOp; end
+    class GT < GenericOp
+      def self.arel_proc
+        proc { |column, op| Arel::Nodes::GreaterThan.new(column, op.expression) }
+      end
+    end
 
-    class LIKE < GenericOp; end
-    class NOT_LIKE < GenericOp; end
-    class ILIKE < GenericOp; end
+    class LT < GenericOp
+      def self.arel_proc
+        proc { |column, op| Arel::Nodes::LessThan.new(column, op.expression) }
+      end
+    end
+
+    class GTE < GenericOp
+      def self.arel_proc
+        proc { |column, op| Arel::Nodes::GreaterThanOrEqual.new(column, op.expression) }
+      end
+    end
+
+    class LTE < GenericOp
+      def self.arel_proc
+        proc { |column, op| Arel::Nodes::LessThanOrEqual.new(column, op.expression) }
+      end
+    end
+
+    class LIKE < GenericOp
+      def self.arel_proc
+        proc { |column, op| Arel::Nodes::Matches.new(column, Arel::Nodes.build_quoted(op.expression, column), nil, true) }
+      end
+    end
+
+    class NOT_LIKE < LIKE
+      def self.arel_proc
+        proc { |column, op| Arel::Nodes::DoesNotMatch.new(column, Arel::Nodes.build_quoted(op.expression, column), nil, true) }
+      end
+    end
+
+    # for postgres:
+
+    class ILIKE < LIKE
+      def self.arel_proc
+        proc { |column, op| Arel::Nodes::Matches.new(column, Arel::Nodes.build_quoted(op.expression, column), nil, false) }
+      end
+    end
+
+    # typically, a Regexp will go through, so this should not becalled
+    # this is here to group proc for regexp with others
+    class REGEXP < GenericOp
+      def self.arel_proc
+        proc { |column, op|  Arel::Nodes::Regexp.new(column, op, !!(op.options && Regexp::IGNORECASE))}
+      end
+    end
   end
 end

--- a/lib/active_record/hash_options/operators.rb
+++ b/lib/active_record/hash_options/operators.rb
@@ -1,10 +1,14 @@
 module ActiveRecord
   module HashOptions
-    GenericOp = Struct.new(:expression)
+    GenericOp = Struct.new(:expression, :expression2)
 
     class GT < GenericOp
       def self.arel_proc
         proc { |column, op| Arel::Nodes::GreaterThan.new(column, op.expression) }
+      end
+
+      def call(val)
+        val && val > expression
       end
     end
 
@@ -12,11 +16,19 @@ module ActiveRecord
       def self.arel_proc
         proc { |column, op| Arel::Nodes::LessThan.new(column, op.expression) }
       end
+
+      def call(val)
+        val && val < expression
+      end
     end
 
     class GTE < GenericOp
       def self.arel_proc
         proc { |column, op| Arel::Nodes::GreaterThanOrEqual.new(column, op.expression) }
+      end
+
+      def call(val)
+        val && val >= expression
       end
     end
 
@@ -24,17 +36,42 @@ module ActiveRecord
       def self.arel_proc
         proc { |column, op| Arel::Nodes::LessThanOrEqual.new(column, op.expression) }
       end
+
+      def call(val)
+        val && val <= expression
+      end
     end
 
     class LIKE < GenericOp
       def self.arel_proc
         proc { |column, op| Arel::Nodes::Matches.new(column, Arel::Nodes.build_quoted(op.expression, column), nil, true) }
       end
+
+      def call(val)
+        expression2 ||= like_to_regex(expression)
+        val && val =~ expression2
+      end
+
+      # escape . * ^ $ (this.gif => this[.]gif - so it won't match this_gif)
+      # leave [] as [] (use by like and regular expressions)
+      # convert % => .*, _ => .
+      # convert ^.*abc$ => abc$
+      # convert ^abc.*$ => ^abc
+      def like_to_regex(lk, extra = nil)
+        exp = lk.gsub(/([.*^$])/) {"[#{$1}]"} # escape special characters
+        exp = "^#{exp}$".gsub("%", '.*').gsub("_", ".").gsub(/^\.\*/, '').gsub(/\.\*$/, '')
+        Regexp.new(exp, extra)
+      end
     end
 
     class NOT_LIKE < LIKE
       def self.arel_proc
         proc { |column, op| Arel::Nodes::DoesNotMatch.new(column, Arel::Nodes.build_quoted(op.expression, column), nil, true) }
+      end
+
+      def call(val)
+        expression2 ||= like_to_regex(expression)
+        val && val !~ expression2
       end
     end
 
@@ -44,6 +81,10 @@ module ActiveRecord
       def self.arel_proc
         proc { |column, op| Arel::Nodes::Matches.new(column, Arel::Nodes.build_quoted(op.expression, column), nil, false) }
       end
+
+      def like_to_regex(lk)
+        super(lk, Regexp::IGNORECASE)
+      end
     end
 
     # typically, a Regexp will go through, so this should not becalled
@@ -51,6 +92,10 @@ module ActiveRecord
     class REGEXP < GenericOp
       def self.arel_proc
         proc { |column, op|  Arel::Nodes::Regexp.new(column, op, !!(op.options && Regexp::IGNORECASE))}
+      end
+
+      def call(val)
+        val && val =~ expression
       end
     end
   end

--- a/test/active_record/array_test.rb
+++ b/test/active_record/array_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ActiveRecord::HashOptionsTest < Minitest::Test
+class ActiveRecord::ArrayTest < Minitest::Test
   include ActiveRecord::HashOptions::Helpers
 
   def test_that_it_has_a_version_number
@@ -8,6 +8,7 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
   end
 
   def test_scope_gt
+    skip("need to test on relations")
     Table1.destroy_all
     Table1.create(:name => "small", :value => 1)
     big = Table1.create(:name => "big", :value => 100)
@@ -23,7 +24,7 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     Table1.create(:name => "small", :value => 1)
     big = Table1.create(:name => "big", :value => 100)
 
-    assert_equal Table1.where(:value => gt(10)), [big]
+    assert_equal Table1.all.to_a.where(:value => gt(10)), [big]
   end
 
   def test_lt
@@ -31,7 +32,7 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     small = Table1.create(:name => "small", :value => 1)
     Table1.create(:name => "big", :value => 100)
 
-    assert_equal Table1.where(:value => lt(10)), [small]
+    assert_equal Table1.all.to_a.where(:value => lt(10)), [small]
   end
 
   # like tests
@@ -41,7 +42,7 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     Table1.create(:name => "small", :value => 1)
     big = Table1.create(:name => "Big", :value => 100)
 
-    assert_equal Table1.where(:name => ilike('%big%')), [big]
+    assert_equal Table1.all.to_a.where(:name => ilike('%big%')), [big]
   end
 
   def test_ilike_case
@@ -49,7 +50,7 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     big1 = Table1.create(:name => "Big", :value => 1)
     big2 = Table1.create(:name => "big", :value => 100)
 
-    assert_equal Table1.where(:name => ilike('%big%')).order(:name), [big1, big2]
+    assert_equal Table1.all.to_a.where(:name => ilike('%big%')).sort_by(&:name), [big1, big2]
   end
 
   def test_like
@@ -57,7 +58,7 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     Table1.create(:name => "small", :value => 1)
     big = Table1.create(:name => "big", :value => 100)
 
-    assert_equal Table1.where(:name => like('%big%')), [big]
+    assert_equal Table1.all.to_a.where(:name => like('%big%')), [big]
   end
 
   def test_not_like
@@ -65,14 +66,13 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     Table1.create(:name => "small", :value => 1)
     big = Table1.create(:name => "big", :value => 100)
 
-    assert_equal Table1.where(:name => not_like('%small%')), [big]
+    assert_equal Table1.all.to_a.where(:name => not_like('%small%')), [big]
   end
 
   # postgres only
 
 
   def test_regexp
-    skip "sqlite has no db support for regexp"
     Table1.destroy_all
     Table1.create(:name => "small", :value => 1)
     big = Table1.create(:name => "big", :value => 100)
@@ -90,7 +90,7 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     Table1.create(:name => "small", :value => 1)
     big = Table1.create(:name => "big", :value => 100)
 
-    assert_equal Table1.where(:name => starts_with('b')), [big]
+    assert_equal Table1.all.to_a.where(:name => starts_with('b')), [big]
   end
 
   def test_ends_with
@@ -98,7 +98,7 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     Table1.create(:name => "small", :value => 1)
     big = Table1.create(:name => "big", :value => 100)
 
-    assert_equal Table1.where(:name => ends_with('g')), [big]
+    assert_equal Table1.all.to_a.where(:name => ends_with('g')), [big]
   end
 
   def test_contains
@@ -106,7 +106,7 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     Table1.create(:name => "small", :value => 1)
     big = Table1.create(:name => "big", :value => 100)
 
-    assert_equal Table1.where(:name => contains('i')), [big]
+    assert_equal Table1.all.to_a.where(:name => contains('i')), [big]
   end
 
   # compound tests
@@ -116,14 +116,15 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     big = Table1.create(:name => "Big", :value => 1)
     Table1.create(:name => "big", :value => 100)
 
-    assert_equal Table1.where(:name => ilike('%big%'), :value => lte(10)), [big]
+    assert_equal Table1.all.to_a.where(:name => ilike('%big%'), :value => lte(10)), [big]
   end
 
   def test_not_compound
+    skip("where.not is not implemented yet for arrays")
     Table1.destroy_all
     big = Table1.create(:name => "Big", :value => 1)
     Table1.create(:name => "big", :value => 100)
 
-    assert_equal Table1.where.not(:name => ilike('%small%'), :value => gte(10)), [big]
+    assert_equal Table1.all.to_a.where.not(:name => ilike('%small%'), :value => gte(10)), [big]
   end
 end


### PR DESCRIPTION
Not the perfect way to mix into array
Also not the perfect way to handle the api, chaining would be better.

But this shows that the same operations can work on ruby collections or sql tables

I had a good example converting regexps to `like` statements, but can not find it.