### PR TITLE
introduce case insensitive matching

### DIFF
--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -18,6 +18,7 @@ module ActiveRecord
         mod.predicate_builder.register_handler(LT, LT.arel_proc)
         mod.predicate_builder.register_handler(GTE, GTE.arel_proc)
         mod.predicate_builder.register_handler(LTE, LTE.arel_proc)
+        mod.predicate_builder.register_handler(INSENSITIVE, INSENSITIVE.arel_proc)
         mod.predicate_builder.register_handler(LIKE, LIKE.arel_proc)
         mod.predicate_builder.register_handler(NOT_LIKE, NOT_LIKE.arel_proc)
         # for postgres:

--- a/lib/active_record/hash_options/helpers.rb
+++ b/lib/active_record/hash_options/helpers.rb
@@ -6,6 +6,8 @@ module ActiveRecord
       def gte(val); ActiveRecord::HashOptions::GTE.new(val); end
       def lte(val); ActiveRecord::HashOptions::LTE.new(val); end
 
+      def insensitive(val); ActiveRecord::HashOptions::INSENSITIVE.new(val); end
+
       def starts_with(val) ; ActiveRecord::HashOptions::LIKE.new("#{val}%"); end
       def ends_with(val) ; ActiveRecord::HashOptions::LIKE.new("%#{val}"); end
       def contains(val) ; ActiveRecord::HashOptions::LIKE.new("%#{val}%"); end

--- a/lib/active_record/hash_options/operators.rb
+++ b/lib/active_record/hash_options/operators.rb
@@ -42,6 +42,20 @@ module ActiveRecord
       end
     end
 
+
+    class INSENSITIVE < GenericOp
+      def self.arel_proc
+        proc do |column, op|
+          lower_column = Arel::Nodes::NamedFunction.new("LOWER", [column])
+          Arel::Nodes::Equality.new(lower_column, Arel::Nodes.build_quoted(op.expression.downcase, column))
+        end
+      end
+
+      def call(val)
+        val&.downcase == expression&.downcase
+      end
+    end
+
     class LIKE < GenericOp
       def self.arel_proc
         proc { |column, op| Arel::Nodes::Matches.new(column, Arel::Nodes.build_quoted(op.expression, column), nil, true) }

--- a/test/active_record/array_test.rb
+++ b/test/active_record/array_test.rb
@@ -35,6 +35,17 @@ class ActiveRecord::ArrayTest < Minitest::Test
     assert_equal Table1.all.to_a.where(:value => lt(10)), [small]
   end
 
+  # case insensitive tests
+
+  def test_insensitive
+    Table1.destroy_all
+    Table1.create(:name => "small", :value => 1)
+    big = Table1.create(:name => "big", :value => 2)
+    big2 = Table1.create(:name => "BIG", :value => 100)
+
+    assert_equal Table1.all.to_a.where(:name => insensitive('big')).sort_by(&:value), [big, big2]
+  end
+
   # like tests
 
   def test_ilike

--- a/test/active_record/hash_options_test.rb
+++ b/test/active_record/hash_options_test.rb
@@ -34,6 +34,17 @@ class ActiveRecord::HashOptionsTest < Minitest::Test
     assert_equal Table1.where(:value => lt(10)), [small]
   end
 
+  # case insensitive tests
+
+  def test_insensitive
+    Table1.destroy_all
+    Table1.create(:name => "small", :value => 1)
+    big = Table1.create(:name => "big", :value => 2)
+    big2 = Table1.create(:name => "BIG", :value => 100)
+
+    assert_equal Table1.where(:name => insensitive('big')).sort_by(&:value), [big, big2]
+  end
+
   # like tests
 
   def test_ilike


### PR DESCRIPTION
Add the ability to use equality in a case insensitive nature

### example

```sql
SELECT *
FROM "tables"
WHERE LOWER("tables"."value") = ?
-- [ "BIg".downcase]
```

### before

It required either arel or manual code

```ruby
Table.where("lower(value) = ?", "BIg".downcase)
# or
column = Table.arel_table[:value]
lower_column = Arel::Nodes::NamedFunction.new("LOWER", [column])
arel_eq = Arel::Nodes::Equality.new(lower_column, Arel::Nodes.build_quoted(="BIg".downcase, column))
Table.where(arel_eq)
```

### After

```ruby
Table.where(:value => insensitive("BIg"))
```