### PR TITLE
add range operations

### DIFF
--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -53,7 +53,7 @@ module ActiveRecord
           col_value = case value
           when Regexp
             actual_val =~ value
-          when Array
+          when Array, Range
             value.include?(actual_val)
           when ActiveRecord::HashOptions::GenericOp
             value.call(actual_val)

--- a/spec/hash_options_spec.rb
+++ b/spec/hash_options_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe ActiveRecord::HashOptions do
     it "compares with lt" do
       expect(filter(collection, :value => lt(10))).to eq([small])
     end
+
+    it "compares with range" do
+      expect(filter(collection, :value => 5..99)).to eq([big])
+    end
   end
 
   shared_examples "string comparable" do


### PR DESCRIPTION
### example

```
value => 1..100
```

### before
 worked for the database, but not in ruby

### after

  works for both