### PR TITLE
use cover for range instead of include

### DIFF
--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -53,8 +53,10 @@ module ActiveRecord
           col_value = case value
           when Regexp
             actual_val =~ value
-          when Array, Range
+          when Array
             value.include?(actual_val)
+          when Range
+            value.cover?(actual_val)
           when ActiveRecord::HashOptions::GenericOp
             value.call(actual_val)
           else # NilClass, String, Integer


### PR DESCRIPTION
turns out that `range.cover` is much faster than `range.include?(string)`
Also, `cover` ends up being more accurate for what we want.

https://gist.github.com/kbrock/86fb7def3f2fa285044cc2bab849161d

### before

```
Finished in 6.39 seconds (files took 0.5136 seconds to load)
45 examples, 0 failures, 1 pending
```

### after

```
Finished in 0.1693 seconds (files took 0.51167 seconds to load)
45 examples, 0 failures, 1 pending
```