### PR TITLE
Add regex conversion to like statements

### DIFF
--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "active_record/hash_options/version"
 require "active_record/hash_options/operators"
+require "active_record/hash_options/operators/regexp"
 require "active_record/hash_options/helpers"
 require "active_record/hash_options/enumerable"
 

--- a/lib/active_record/hash_options/operators.rb
+++ b/lib/active_record/hash_options/operators.rb
@@ -117,21 +117,5 @@ module ActiveRecord
         super(lk, Regexp::IGNORECASE)
       end
     end
-
-    # typically, a Regexp will go through, so this should not becalled
-    # this is here to group proc for regexp with others
-    class REGEXP < GenericOp
-      def self.arel_proc
-        proc do |column, op|
-          regexp_text = Arel::Nodes.build_quoted(op.source, column)
-          case_sensitive = (op.options & Regexp::IGNORECASE == 0)
-          Arel::Nodes::Regexp.new(column, regexp_text, case_sensitive)
-        end
-      end
-
-      def call(val)
-        val && val =~ expression
-      end
-    end
   end
 end

--- a/lib/active_record/hash_options/operators/regexp.rb
+++ b/lib/active_record/hash_options/operators/regexp.rb
@@ -1,16 +1,82 @@
 module ActiveRecord
   module HashOptions
+    # typically, a Regexp will go through, so this should not be called
+    # this is here to group proc for regexp with others
     class REGEXP < GenericOp
       def self.arel_proc
         proc do |column, op|
-          regexp_text = Arel::Nodes.build_quoted(op.source, column)
-          case_sensitive = (op.options & Regexp::IGNORECASE == 0)
-          Arel::Nodes::Regexp.new(column, regexp_text, case_sensitive)
+          mode, case_sensitive, source = convert_regex(op)
+          source = Arel::Nodes.build_quoted(source)
+          # case_sensitive &&= case_sensitive_database && case_sensitive_column
+          # mode = "like" if mode == "=" && !case_sensitive && !use_lower_function
+          case mode
+          when '='
+            if case_sensitive
+              Arel::Nodes::Equality.new(column, source)
+            else
+              Arel::Nodes::Equality.new(Arel::Nodes::NamedFunction.new("LOWER", [column]), source.downcase.gsub(/\\/, ""))
+            end
+          when 'like'
+            Arel::Nodes::Matches.new(column, source, nil, case_sensitive)
+          when '~'
+            Arel::Nodes::Regexp.new(column, source, case_sensitive)
+          end
         end
       end
 
       def call(val)
         val && val =~ expression
+      end
+
+      # convert a regexp to a string if possible
+      # the order of the operations matter so you don't double convert some phrases
+      # in regex: wildcards: .,.* escaping: \,[], please_escape: .,*
+      # in like:  wildcards: _,%  escaping: \ (some databases support [] - but punting for now)
+      #
+      # currently can't handle {}, (), [] (with more than 1 character) (non .)*
+      def self.regex_to_like(regex)
+        source = regex.source
+
+        # .* (any number of any character) is ok, but {specific}* (any number of a particular letter is not ok)
+        # [.] to escape a single character is ok (e.g. '.' or '*') - but any other use is not ok in postgres
+        return if source =~ /([^.]\*|\[.{2,}\])/
+
+        # convert anchors into wild characters
+        source = (source[0] == "^")  ? source[1..-1] : "%#{source}"
+        source = (source[-1] == "$") ? source[0..-2] : "#{source}%"
+
+        # don't want to modify the regex, and unfreeze the anchor conversions
+        source = source.dup
+
+        # escape _, % unless already being escaped
+        # convert [] escaping single letter => backslash escaping
+        source.gsub!(/\[(.)\]/) { "\\#{$1}" }
+        # convert .* (any number of any characters) => %
+        source.gsub!('.*', '%')
+        # convert . => _ unless already being escaped
+        # to be honest, we probably don't use this and it is probably a bug in our source
+        source.gsub!(/(?<![\\])\./, '_')
+        # unescape \., \* -- they don't need to be escaped in sql
+        source.gsub!(/(\\)([.*])/) { $2 }
+        # condense multiple %'s
+        source.gsub!(/(?<![\\])%%+/, '%')
+        # can leave '\.' escaped, but fix []'
+        # only suggest a like or equals if we've removed all regular expression stuff
+        source unless source =~ /[\[\]()*{}]/
+      end
+
+      # if it is simple enough, just use a regular sql like clause. or even an =
+      def self.convert_regex(regex)
+        case_sensitive = !(regex.options & Regexp::IGNORECASE > 0)
+        source = regex_to_like(regex)
+
+        if source.nil?
+          ["~", case_sensitive, regex.source]
+        elsif source !~ /([^\\]|^)[%_]/
+          ["=", case_sensitive, source]
+        else
+          ["like", case_sensitive, source]
+        end
       end
     end
   end

--- a/lib/active_record/hash_options/operators/regexp.rb
+++ b/lib/active_record/hash_options/operators/regexp.rb
@@ -1,0 +1,17 @@
+module ActiveRecord
+  module HashOptions
+    class REGEXP < GenericOp
+      def self.arel_proc
+        proc do |column, op|
+          regexp_text = Arel::Nodes.build_quoted(op.source, column)
+          case_sensitive = (op.options & Regexp::IGNORECASE == 0)
+          Arel::Nodes::Regexp.new(column, regexp_text, case_sensitive)
+        end
+      end
+
+      def call(val)
+        val && val =~ expression
+      end
+    end
+  end
+end

--- a/spec/hash_options_spec.rb
+++ b/spec/hash_options_spec.rb
@@ -169,12 +169,22 @@ RSpec.describe ActiveRecord::HashOptions do
   ########## string regular expressions ##########
 
   shared_examples "regexp comparable" do
-    it "compares with regexp" do
+    it "compares with regexp lowercase" do
       skip("db #{db_type} does not support regexps") unless array_test? || pg?
 
       expect(filter(collection, :name => /^bi.*/)).to eq([big])
+    end
+
+    it "compares with regexp mixed case" do
+      skip("db #{db_type} does not support regexps") unless array_test? || pg?
+
       expect(filter(collection, :name => /^Bi.*/)).to eq([])
-      expect(filter(collection, :name => /^Bi.*/i)).to eq([big, big2])
+    end
+
+    it "compares with regexp case insensitive" do
+      skip("db #{db_type} does not support regexps") unless array_test? || pg?
+
+      expect(filter(collection, :name => /^Bi.*/i)).to match_array([big, big2])
     end
   end
 

--- a/spec/hash_options_spec.rb
+++ b/spec/hash_options_spec.rb
@@ -169,22 +169,36 @@ RSpec.describe ActiveRecord::HashOptions do
   ########## string regular expressions ##########
 
   shared_examples "regexp comparable" do
-    it "compares with regexp lowercase" do
-      skip("db #{db_type} does not support regexps") unless array_test? || pg?
-
-      expect(filter(collection, :name => /^bi.*/)).to eq([big])
+    it "compares with regexp lowercase (like)" do
+      if case_sensitive_like?
+        expect(filter(collection, :name => /^bi.*/)).to eq([big])
+      else
+        expect(filter(collection, :name => /^bi.*/)).to match_array([big, big2])
+      end
     end
 
-    it "compares with regexp mixed case" do
+    it "compares with regexp mixed case (like)" do
+      if case_sensitive_like?
+        expect(filter(collection, :name => /^Bi.*/)).to eq([])
+      else
+        expect(filter(collection, :name => /^Bi.*/)).to match_array([big, big2])
+      end
+    end
+
+    it "compares with regexp case insensitive (ilike)" do
+      expect(filter(collection, :name => /^Bi.*/i)).to match_array([big, big2])
+    end
+
+    it "compares with regexp case sensitive" do
       skip("db #{db_type} does not support regexps") unless array_test? || pg?
 
-      expect(filter(collection, :name => /^Bi.*/)).to eq([])
+      expect(filter(collection, :name => /^bi*g/)).to match_array([big])
     end
 
     it "compares with regexp case insensitive" do
       skip("db #{db_type} does not support regexps") unless array_test? || pg?
 
-      expect(filter(collection, :name => /^Bi.*/i)).to match_array([big, big2])
+      expect(filter(collection, :name => /^Bi*g/i)).to match_array([big, big2])
     end
   end
 

--- a/spec/regexp_spec.rb
+++ b/spec/regexp_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+RSpec.describe ActiveRecord::HashOptions::REGEXP do
+  describe ".convert_regex" do
+    # regex
+    it "detects case insensitive regex" do
+      expect(described_class.convert_regex(/a[a-z]*b/i)).to eq(["~", false, "a[a-z]*b"])
+    end
+
+    it "detects case sensitive regex" do
+      expect(described_class.convert_regex(/a[a-z]*b/)).to eq(["~", true, "a[a-z]*b"])
+    end
+
+    it "detects incompatible wildcard" do
+      expect(described_class.convert_regex(/a*/)).to eq(["~", true, "a*"])
+    end
+
+    it "detects incompattible period wildcard" do
+      expect(described_class.convert_regex(/file[.]*txt/)).to eq(["~", true, "file[.]*txt"])
+    end
+
+    # like
+
+    it "detects case sensative like" do
+      expect(described_class.convert_regex(/ab/)).to eq(["like", true, "%ab%"])
+    end
+
+    it "detects case insensitive like" do
+      expect(described_class.convert_regex(/ab/i)).to eq(["like", false, "%ab%"])
+    end
+
+    it "detects like left anchor" do
+      expect(described_class.convert_regex(/^ab/)).to eq(["like", true, "ab%"])
+    end
+
+    it "detects like right anchor" do
+      expect(described_class.convert_regex(/ab$/)).to eq(["like", true, "%ab"])
+    end
+
+    it "supports wildcard .* => %" do # stretch
+      expect(described_class.convert_regex(/^this.*that$/)).to eq(["like", true, "this%that"])
+    end
+
+    it "supports single character wildcard . => _" do # stretch (bug)
+      expect(described_class.convert_regex(/^this.that$/)).to eq(["like", true, "this_that"])
+    end
+
+    it "supports escaped period (\\.) to like" do
+      expect(described_class.convert_regex(/file\.txt$/)).to eq(["like", true, "%file.txt"])
+    end
+
+    it "supports escaped period ([.]) to like" do
+      expect(described_class.convert_regex(/file[.]txt$/)).to eq(["like", true, "%file.txt"])
+    end
+
+    it "supports escaped period (Regexp.escape)" do
+      expect(described_class.convert_regex(/#{Regexp.escape("file.txt")}$/)).to eq(["like", true, "%file.txt"])
+    end
+
+    # equality
+
+    it "detects equality" do
+      expect(described_class.convert_regex(/^ab$/)).to eq(["=", true, "ab"])
+    end
+
+    it "detects case insensitive equality" do
+      expect(described_class.convert_regex(/^ab$/i)).to eq(["=", false, "ab"])
+    end
+
+    it "detects escaped % ([%]) to equals" do
+      expect(described_class.convert_regex(/^a[%]b$/)).to eq(["=", true, "a\\%b"])
+    end
+
+    it "detects escaped % (\\%) to equals" do
+      expect(described_class.convert_regex(/^a\%b$/)).to eq(["=", true, "a\\%b"])
+    end
+
+    it "detects escaped % ([%]) followed by wildcard " do
+      expect(described_class.convert_regex(/^a[%]/)).to eq(["like", true, "a\\%%"])
+    end
+
+    it "detects escaped % ([%]) to equals" do
+      expect(described_class.convert_regex(/^a\%b$/)).to eq(["=", true, "a\\%b"])
+    end
+  end
+end


### PR DESCRIPTION
It is very convenient to use the regular expression syntax to express case insensitive comparison and most of the string comparison syntaxes like `contains`, `begins with`, and `ends with`.

Unfortunately using like and regular = is more performant than regular expression matching.

This adds support to allow developers to use regular expressions in the ruby code, but it convert basic regular expressions to other more performant sql matching strategies.

so

```ruby
Model.where(:column => /^a$/)
# becomes => "="
Model.where(:column => "a")

Model.where(:column => /^a/i)
# becomes => "ILIKE"
Model.where(Model.arel_table[:column].matches("a%"))
```

This adds a lot of complexity to the regular expression syntax. Especially considering that the first version of this gem was only 53 lines long.

But in my opinion, using regular expressions is nicer than adding all the predicates.
Between ranges and regular expressions, a developer will have most of the functionality of this gem.