### PR TITLE
Add more compares

### DIFF
--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -52,19 +52,18 @@ module ActiveRecord
       array.select do |rec|
         conditions.all? do |name, value|
           actual_val = rec.send(name)
-          # not thrilled about special cases, but in (array with nil) or == nil are the only cases
-          # that handle negation for a nil value correctly
+          # not thrilled about special cases, but `x in [..., nil]` and `x == nil` are the only cases
+          # that handle negation for a `nil` / `null` value correctly
           if actual_val.nil? && (value != nil || value.kind_of?(Array) && !value.include?(nil))
             false
           else
-            col_value = compare_array_column(actual_val, value, negate)
-            negate ? !col_value : col_value
+            compare_array_column(actual_val, value) ? !negate : negate
           end
         end
       end
     end
 
-    def self.compare_array_column(actual_val, value, negate)
+    def self.compare_array_column(actual_val, value)
       case value
       when Regexp
         actual_val =~ value
@@ -73,10 +72,10 @@ module ActiveRecord
       when Range
         value.cover?(actual_val)
       when ActiveRecord::HashOptions::GenericOp
-        # NOTE: nil check in filter_array may short circuited this comparison
+        # NOTE: The `nil?` check in `filter_array` may skip this comparison and short circuit to a false
         value.call(actual_val)
       else # NilClass, String, Integer
-        # NOTE: treats == nil as IS NULL
+        # NOTE: this treats `x == nil` the same as `x IS NULL`
         actual_val == value
       end
     end

--- a/spec/hash_options_spec.rb
+++ b/spec/hash_options_spec.rb
@@ -59,11 +59,27 @@ RSpec.describe ActiveRecord::HashOptions do
   ########## string comparisons ##########
 
   shared_examples "string comparable" do
-    it "compares with gt" do
-      if case_sensitive_string_compare?
+    it "compares with =" do
+      if pg? || array_test? || sqlite?
+        expect(filter(collection, :name => "big")).to eq([big])
+      else # mysql?
+        expect(filter(collection, :name => "big")).to match_array([big, big2])
+      end
+    end
+
+    it "compares with gt lower" do
+      if linux_pg?
         expect(filter(collection, :name => gt("big"))).to match_array([small, big2])
       else
         expect(filter(collection, :name => gt("big"))).to eq([small])
+      end
+    end
+
+    it "compares with gt upper" do
+      if array_test? || mac_pg? || sqlite?
+        expect(filter(collection, :name => gt("BIG"))).to match_array([small, big])
+      else
+        expect(filter(collection, :name => gt("BIG"))).to eq([small])
       end
     end
 
@@ -75,16 +91,24 @@ RSpec.describe ActiveRecord::HashOptions do
       expect(filter(collection, :name => lt("small"))).to match_array([big, big2])
     end
 
-    it "compares with lte" do
-      if case_sensitive_string_compare?
+    it "compares with lte lower" do
+      if linux_pg?
         expect(filter(collection, :name => lte("big"))).to eq([big])
       else
         expect(filter(collection, :name => lte("big"))).to match_array([big, big2])
       end
     end
 
+    it "compares with lte upper" do
+      if linux_pg? || mysql?
+        expect(filter(collection, :name => lte("BIG"))).to match_array([big, big2])
+      else
+        expect(filter(collection, :name => lte("BIG"))).to match_array([big2])
+      end
+    end
+
     it "compares with range" do
-      if case_sensitive_range?
+      if array_test? || mac_pg? || sqlite?
         expect(filter(collection, :name => "big"..."small")).to eq([big])
         expect(filter(collection, :name => "big".."small")).to match_array([big, small])
       else
@@ -195,14 +219,6 @@ RSpec.describe ActiveRecord::HashOptions do
     array_test? || pg?
   end
 
-  def case_sensitive_range?
-    array_test? || (pg? && mac?) || sqlite?
-  end
-
-  def case_sensitive_string_compare?
-    !mac? && pg?
-  end
-
   def mac?
     Gem::Platform.local.os == "darwin"
   end
@@ -217,6 +233,18 @@ RSpec.describe ActiveRecord::HashOptions do
 
   def pg?
     db_type == "pg" && !array_test?
+  end
+
+  def mac_pg?
+    mac? && pg?
+  end
+
+  def linux_pg?
+    !mac? && pg?
+  end
+
+  def mysql?
+    db_type == "mysql2" && !array_test?
   end
 
   def sqlite?

--- a/spec/hash_options_spec.rb
+++ b/spec/hash_options_spec.rb
@@ -1,6 +1,10 @@
 Array.send(:include, ActiveRecord::HashOptions::Enumerable)
 
 RSpec.describe ActiveRecord::HashOptions do
+  def self.db_type
+    ENV["DB"]
+  end
+
   before do
     Table1.destroy_all
   end
@@ -142,7 +146,7 @@ RSpec.describe ActiveRecord::HashOptions do
 
   shared_examples "regexp comparable" do
     it "compares with regexp" do
-      skip("db #{ENV["db"]} does not support regexps") unless array_test? || pg?
+      skip("db #{db_type} does not support regexps") unless array_test? || pg?
 
       expect(filter(collection, :name => /^bi.*/)).to eq([big])
       expect(filter(collection, :name => /^Bi.*/)).to eq([])
@@ -175,7 +179,7 @@ RSpec.describe ActiveRecord::HashOptions do
     it_should_behave_like "compound comparable"
   end
 
-  describe "Scope" do
+  describe "Scope #{db_type}" do
     let(:collection) { Table1 }
 
     it_should_behave_like "scope comparable"
@@ -207,16 +211,23 @@ RSpec.describe ActiveRecord::HashOptions do
     collection.kind_of?(Array)
   end
 
+  def db_type
+    self.class.db_type
+  end
+
   def pg?
-    ENV["DB"] == "pg" && !array_test?
+    db_type == "pg" && !array_test?
   end
 
   def sqlite?
-    ENV["DB"] == "sqlite3" && !array_test?
+    db_type == "sqlite3" && !array_test?
   end
 
+  # filter a collection
+  # this is typically called via:
+  #   ActiveRecord::HashOptions.filter(collection, conditions, negate)
+  # although there are many ways to reduce the typing - see the readme.
   def filter(collection, conditions, negate = false)
-    # ActiveRecord::HashOptions.filter(collection, conditions, negate)
     if negate
       collection.where.not(conditions)
     else

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,4 +1,4 @@
-  require "logger"
+require "logger"
 require "active_record"
 
 class Database
@@ -8,6 +8,8 @@ class Database
   end
 
   def adapter
+    ENV['DB'] = "sqlite3" if ENV['DB'] == "sqlite"
+    ENV['DB'] = "mysql2"  if ENV['DB'] == "mysql"
     ENV['DB'] ||= "sqlite3"
   end
 


### PR DESCRIPTION
String comparing uppercase and lowercase is confusing for me.
It seems every database does it a bit differently.

This adds some tests to help suss out the issues at play for the various platforms.

I'm not sure if it is case sensitivity or if it is a differences of sort order for upper and lower case characters.

One great example is the difference between postgres's uppercase and lowercase string comparison. The mac is case sensitive while ubuntu (travis systems) is case insensitive.