### PR TITLE
only setup database if it is applicable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ gemfile:
   - gemfiles/gemfile_60.gemfile
 
 before_script:
-  - mysql -e 'create database hash_options_test;' || true
-  - psql -c 'create database hash_options_test;' -U postgres || true
+  - sh -c "[ '$DB' = 'mysql2' ] && mysql -e 'create database hash_options_test;' || true"
+  - sh -c "[ '$DB' = 'pg' ] && psql -c 'create database hash_options_test;' -U postgres || true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ gemfile:
   - gemfiles/gemfile_60.gemfile
 
 before_script:
-  - sh -c "[ '$DB' = 'mysql2' ] && mysql -e 'create database hash_options_test;' || true"
-  - sh -c "[ '$DB' = 'pg' ] && psql -c 'create database hash_options_test;' -U postgres || true"
+  - [ '$DB' = 'mysql2' ] && mysql -e 'create database hash_options_test;' || true
+  - [ '$DB' = 'pg' ] && psql -c 'create database hash_options_test;' -U postgres || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.5.5
+  - 2.5.3
 
 services:
   - mysql

--- a/activerecord-hash_options.gemspec
+++ b/activerecord-hash_options.gemspec
@@ -19,8 +19,11 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "appraisal"
+  # We use appraisal to generate the gemfiles
+  # but other than that, we do not use appraisal during the runtime/development time of gem
+  # spec.add_development_dependency "appraisal"
   spec.add_development_dependency "rake", ">= 12.3.3"
-  spec.add_development_dependency "rspec", "~>3.8.0"
+  spec.add_development_dependency "rspec-core", "~>3.8.0"
+  spec.add_development_dependency "rspec-expectations", "~>3.8.0"
   spec.add_development_dependency "activerecord", ">= 5.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,10 +12,6 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
-  config.mock_with :rspec do |mocks|
-    mocks.verify_partial_doubles = true
-  end
-
   # default for rspec 4, manually set in rspec 3
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.disable_monkey_patching!


### PR DESCRIPTION
trying to reduce the work running on travis.

- conditionally setup databases (easy)
- conditionally boot services (not sure if I can get this)

---

I would like to delete the `services:` list but not able to implement that behavior in the shell.
It showed promise but I couldn't run the scripts that the current shell calls.

```yaml
before_script:
  - sh -c "[ '$DB' = 'mysql2' ] && sudo systemctl start mysql && mysql -e 'create database hash_options_test;' || true"
  - sh -c "[ '$DB' = 'pg' ] && travis_setup_postgresql && sudo systemctl start postgresql@9.6-main || true"
  - sh -c "[ '$DB' = 'pg' ] && psql -c 'create database hash_options_test;' -U postgres || true"
```