### PR TITLE
Move special handling of nils into operators themselves

### DIFF
--- a/lib/active_record/hash_options/operators.rb
+++ b/lib/active_record/hash_options/operators.rb
@@ -25,7 +25,7 @@ module ActiveRecord
       end
 
       def call(val)
-        val && val > expression
+        val.nil? ? nil : val > expression
       end
     end
 
@@ -35,7 +35,7 @@ module ActiveRecord
       end
 
       def call(val)
-        val && val < expression
+        val.nil? ? nil : val < expression
       end
     end
 
@@ -45,7 +45,7 @@ module ActiveRecord
       end
 
       def call(val)
-        val && val >= expression
+        val.nil? ? nil : val >= expression
       end
     end
 
@@ -55,7 +55,7 @@ module ActiveRecord
       end
 
       def call(val)
-        val && val <= expression
+        val.nil? ? nil : val <= expression
       end
     end
 
@@ -68,7 +68,9 @@ module ActiveRecord
       end
 
       def call(val)
-        val&.downcase == expression&.downcase
+        # a little odd to case insensitive compare with nil.
+        # but it seems possible that this may come out of a regular expression translation
+        val.nil? ? (expression.nil? ? true : nil) : val.downcase == expression&.downcase
       end
     end
 
@@ -81,7 +83,7 @@ module ActiveRecord
 
       def call(val)
         expression2 ||= like_to_regex(expression)
-        val && val =~ expression2
+        val.nil? ? nil : !!(val =~ expression2)
       end
 
       # escape . * ^ $ (this.gif => this[.]gif - so it won't match this_gif)
@@ -104,7 +106,7 @@ module ActiveRecord
 
       def call(val)
         expression2 ||= like_to_regex(expression)
-        val && val !~ expression2
+        val.nil? ? nil : !!(val !~ expression2)
       end
     end
 


### PR DESCRIPTION
The leaky abstraction around nulls broke down and need to move into
the operators themselves.

Now the comparisons return true, false, and a nil (representing a bad comparison with null).
This is complicated but unfortunately necessary to properly support negation.

Sql uses null to represent unknown, ruby uses nil to represent no value.

Since they are so similar, ActiveRecord simplifies `where(:x => nil)`
to be `x IS NULL` and not literally `x == NULL`. This causes ruby and sql logic to
deviate a little. It also breaks the commutative and distributive properties
for the null edge cases. Not having distributive properties means negation
needs to handle these edge cases and the code becomes be more complicated.

The expression on the left represents a column value,
and the expression on the right represents what it is compared against.
So in ruby it would be `Model.where(:col => "x")` and `Model.where.not(:col => "x")`
and in sql it would be `WHERE col == "x"`.

expression  | ruby | sql    | Active Record and Hash Options
------------|------|----    |-----
'x' == 'x'  | true | true   | true
'x' != 'x'  | false| false  | false
'x' == 'y'  | false| false  | false
'x' != 'y'  | true | true   | true
'x' == nil  | false| false  | false (treated as IS NULL)
'x' != nil  | true | **false**| true (treated as IS NOT NULL)
nil == nil  | true | **false**| true (treated as IS NULL)
nil != nil  | false| false  | false (treated as IS NOT NULL)
nil IS NULL | n/a  | true   | n/a (merged with the == nil case)
nil == 'x'  | false| false  | false (NOTE: these are not treated as IS NULL)
nil != 'x'  | true | **false**| **false**
!(nil =='x')| true | true   | true
!(nil !='x')| false| **true** | **true**
!('x' ==nil)| true | true   | true (treated as IS NULL)
!('x' !=nil)| false| **true** | false? (treated as IS NULL)

the nil case seems like it can be glossed over except when dealing with negation.
Note: `nil != 'x'` has a different value from `!(x == nil)` and
`nil != 'x' has a different value from `'x' != nil`.