### PR TITLE
fix the rake command to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Person.all.to_a.where.not(:age => gte(21))
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake` to run the tests.
 
 You can also run `bin/console` for an interactive prompt that will allow you to experiment. Model `Table1` will be available
 for your convenience


### PR DESCRIPTION
since we have the default set (`task :default => :spec`) and I don't actually think `rake test` works, maybe this should just be `rake`

```
00:58 $ rake test
rake aborted!
Don't know how to build task 'test' (See the list of available tasks with `rake --tasks`)
/Users/drewmu/.rvm/gems/ruby-2.6.3/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/Users/drewmu/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `eval'
/Users/drewmu/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `<main>'
(See full trace by running task with --trace)
✘-1 ~/activerecord-hash_options [master ↑·6|✔]
00:58 $ rake spec
/Users/drewmu/.rvm/rubies/ruby-2.6.3/bin/ruby -w -I/Users/drewmu/.rvm/gems/ruby-2.6.3/gems/rspec-core-3.8.2/lib:/Users/drewmu/.rvm/gems/ruby-2.6.3/gems/rspec-support-3.8.3/lib /Users/drewmu/.rvm/gems/ruby-2.6.3/gems/rspec-core-3.8.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Randomized with seed 35588
............................**...................................................
```