### PR TITLE
fix loaderror from bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -4,7 +4,6 @@ require "bundler/setup"
 require "activerecord/hash_options"
 
 # models for local testing
-require "rspec"
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 require "irb"


### PR DESCRIPTION
I don't believe this is required for tests anyway (I mean not _here_):

```
$ bin/console
Traceback (most recent call last):
	1: from bin/console:7:in `<main>'
bin/console:7:in `require': cannot load such file -- rspec (LoadError)
```