### PR TITLE
Newer ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "activerecord", '~> 5.2'
+gem "activerecord", '~> 6.0.1'
 gem "mysql2"
 gem "pg"
 gem "sqlite3"
+
+gem "byebug"

--- a/activerecord-hash_options.gemspec
+++ b/activerecord-hash_options.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-core", "~>3.8.0"
   spec.add_development_dependency "rspec-expectations", "~>3.8.0"
   spec.add_development_dependency "activerecord", ">= 5.0"
+  spec.add_development_dependency "erb"
 end


### PR DESCRIPTION
erb is required for ruby 2.7 or 3.0 - either way, explicitly requiring it.
also adding to gemspec

since this is only used in tests, keeping as a development dependency