### PR TITLE
Rails7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,12 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+  schedule:
+   - cron: '0 0 * * *'
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -77,10 +83,9 @@ jobs:
         env:
           DB: pg
           # latin1 locale on mac is borked, so just using ascii / c / posix
-          LOCALE: POSIX
+          LOCALE: C
         run: |
-          psql -U postgres --host 127.0.0.1 --port 5432 -c "create database hash_options_test locale ${LOCALE} template template0;"
-          psql -l
+          psql -U postgres --host 127.0.0.1 --port 5432 -c "create database hash_options_test ENCODING utf8 locale 'C' template template0;"
           bundle exec rake
 
       - name: run mysql tests
@@ -88,7 +93,7 @@ jobs:
           DB: mysql2
           MYSQL_DATABASE: hash_options_test
         run: |
-          mysql --host 127.0.0.1 --port 3306 -uroot -e "CREATE DATABASE IF NOT EXISTS hash_options_test CHARACTER SET latin1;"
+          mysql --host 127.0.0.1 --port 3306 -uroot -e "CREATE DATABASE hash_options_test CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;"
           bundle exec rake
 
       - name: run sqlite tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,24 +9,29 @@ jobs:
   test:
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:13
+        ports:
+          - "5432:5432"
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: test
+          # manually create our with a locale
+          # POSTGRES_DB: postgres
+          POSTGRES_INITDB_ARGS: "--locale POSIX"
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
       mysql:
-          image: mysql:5.7
+          image: mysql:8.0
           env:
-            MYSQL_DATABASE: hash_options_test
-            MYSQL_ALLOW_EMPTY_PASSWORD: yes
-            MYSQL_PASSWORD:
+            # locally: use database ; SET PASSWORD FOR root@localhost = 'password' ;
+            MYSQL_ROOT_PASSWORD: password
+            # manually create with a locale
+            # MYSQL_DATABASE: test
           ports:
-            - 3306
+            - "3306:3306"
           options: >-
             --health-cmd="mysqladmin ping"
             --health-interval=10s
@@ -34,64 +39,57 @@ jobs:
             --health-retries=3
     runs-on: ubuntu-latest
     strategy:
+      # fail-fast: false
       matrix:
-        include:
-          - ruby: 2.5
-            activerecord: 52
-          - ruby: 2.7
-            activerecord: 60
-          - ruby: 2.7
-            activerecord: 61
-          - ruby: 3.0
-            activerecord: 61
+        activerecord: [70, 71]
+        ruby: ["3.2"]
+        # include:
+          # - ruby: 2.7
+          #   activerecord: 61
+          # rails 6.1 and 7.0 have different ruby versions
+          # - ruby: 2.7
+          #   activerecord: 61
+          # - ruby: "3.0"
+          #   activerecord: 61
     env:
-       PGUSER: postgres
-       PGPASSWORD: postgres
-       PGDATABASE: postgres
-       PGHOST: 127.0.0.1
-       PGPORT: 5432
-       BUNDLE_GEMFILE: gemfiles/gemfile_${{ matrix.activerecord }}.gemfile
-       MYSQL_DATABASE: hash_options_test
-
+      # for the pg cli (psql)
+      PGHOST: "127.0.0.1"
+      PGPORT: 5432
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      # for the mysql cli (mysql)
+      MYSQL_HOST: 127.0.0.1
+      MYSQL_PORT: 3306
+      MYSQL_PWD: password
+      # for rails tests (from matrix)
+      BUNDLE_GEMFILE: gemfiles/gemfile_${{ matrix.activerecord }}.gemfile
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: setup Ruby
-        # This will automatically get bug fixes and new Ruby versions (see https://github.com/ruby/setup-ruby#versioning)
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-
-      - name: install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-
-      - name: setup mysql test database
-        run: |
-          sudo apt-get update && sudo apt-get install -y mysql-client
-          sudo /etc/init.d/mysql start
-          mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -e 'CREATE SCHEMA IF NOT EXISTS 'hash_options_test';'
-
-      - name: setup postgres test database
-        run: |
-          sudo /etc/init.d/postgresql start
-          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
-          psql -U postgres -c 'create database hash_options_test;'
+          bundler-cache: true
 
       - name: run pg tests
         env:
           DB: pg
-        run: bundle exec rake
+          # latin1 locale on mac is borked, so just using ascii / c / posix
+          LOCALE: POSIX
+        run: |
+          psql -U postgres --host 127.0.0.1 --port 5432 -c "create database hash_options_test locale ${LOCALE} template template0;"
+          psql -l
+          bundle exec rake
 
       - name: run mysql tests
         env:
           DB: mysql2
           MYSQL_DATABASE: hash_options_test
-          PORT: ${{ job.services.mysql.ports[3306] }}
-        run: bundle exec rake
+        run: |
+          mysql --host 127.0.0.1 --port 3306 -uroot -e "CREATE DATABASE IF NOT EXISTS hash_options_test CHARACTER SET latin1;"
+          bundle exec rake
 
       - name: run sqlite tests
         env:

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,13 @@
-# this should support 4.1 and higher
 # git log on this file will show how to generate the gemfiles for this
-%w(5.2.3 6.0.0 6.1.0).each do |ar_version|
+%w(6.0.0 6.1.0 7.0 7.1).each do |ar_version|
   appraise "gemfile-#{ar_version.split('.').first(2).join}" do
     gem "activerecord", "~> #{ar_version}"
+    remove_gem "byebug"
+    if ar_version < "7.0"
+      gem "sqlite3", "~> 1.6.9"
+    else
+      # sqlite3 v 2.0 is causing trouble with rails
+      gem "sqlite3", "< 2.0"
+    end
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "activerecord", '~> 6.1.1'
+gem "activerecord", '~> 7.0'
 gem "mysql2"
 gem "pg"
 gem "sqlite3", '~> 1.4'

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "activerecord", '~> 6.0.1'
+gem "activerecord", '~> 6.1.1'
 gem "mysql2"
 gem "pg"
-gem "sqlite3"
+gem "sqlite3", '~> 1.4'
 
 gem "byebug"

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "activerecord/hash_options"
+require "active_record"
+require "active_record/hash_options"
 
 # models for local testing
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }

--- a/bin/setup
+++ b/bin/setup
@@ -6,3 +6,13 @@ set -vx
 bundle install
 
 # Do any other automated setup that you need to do here
+# eval $(grep -i "create database hash" .github/workflows/main.yml)
+psql -U postgres --host 127.0.0.1 --port 5432 -c "drop database hash_options_test"
+psql -U postgres --host 127.0.0.1 --port 5432 -c "create database hash_options_test ENCODING utf8 locale 'C' template template0;"
+
+mysql --host ${MYSQL_HOST:-127.0.0.1} --port ${MYSQL_PORT:-3306} -u${MYSQL_USER:-root} -e "DROP DATABASE hash_options_test;"
+mysql --host ${MYSQL_HOST:-127.0.0.1} --port ${MYSQL_PORT:-3306} -u${MYSQL_USER:-root} -e "CREATE DATABASE hash_options_test CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;"
+
+#psql -U postgres -c "create database hash_options_test LOCALE 'en_US.UTF-8' ENCODING 'UTF-8';"
+#mysql -uroot -e "CREATE DATABASE IF NOT EXISTS hash_options_test CHARACTER SET utf8 COLLATE utf8mb3_general_ci;"
+

--- a/gemfiles/gemfile_61.gemfile
+++ b/gemfiles/gemfile_61.gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 gem "activerecord", "~> 6.1.0"
 gem "mysql2"
 gem "pg"
-gem "sqlite3"
+gem "sqlite3", "~> 1.6.9"
 
 gemspec path: "../"

--- a/gemfiles/gemfile_70.gemfile
+++ b/gemfiles/gemfile_70.gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.0.0"
+gem "activerecord", "~> 7.0"
 gem "mysql2"
 gem "pg"
-gem "sqlite3", "~> 1.6.9"
+gem "sqlite3", "< 2.0"
 
 gemspec path: "../"

--- a/gemfiles/gemfile_71.gemfile
+++ b/gemfiles/gemfile_71.gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.2.3"
+gem "activerecord", "~> 7.1"
 gem "mysql2"
 gem "pg"
-gem "sqlite3"
+gem "sqlite3", "< 2.0"
 
 gemspec path: "../"

--- a/spec/db/database.yml
+++ b/spec/db/database.yml
@@ -1,9 +1,10 @@
 common: &common
   database: hash_options_test
   encoding: utf8
-  host: localhost
+  host: "127.0.0.1"
   pool: 3
   wait_timeout: 5
+  min_messages: WARNING
 
 sqlite3:
   <<: *common
@@ -13,14 +14,13 @@ sqlite3:
 pg:
   <<: *common
   adapter: postgresql
-  username: postgres
-  min_messages: WARNING
+  username: <%= ENV.fetch("PGUSER", "postgres") %>
+  password: <%= ENV.fetch("PGPASSWORD", "postgres") %>
   schema_search_path: public
 
 mysql2:
+  << : *common
   adapter: mysql2
-  host: 127.0.0.1
-  encoding: utf8
-  database: <%= ENV["MYSQL_DATABASE"].presence %>
-  port: <%= ENV["PORT"].presence&.to_i || 3306 %>
+  port: 3306
   username: root
+  password: <%= ENV.fetch("MYSQL_PWD", "password") %>

--- a/spec/db/database.yml
+++ b/spec/db/database.yml
@@ -17,6 +17,8 @@ pg:
   username: <%= ENV.fetch("PGUSER", "postgres") %>
   password: <%= ENV.fetch("PGPASSWORD", "postgres") %>
   schema_search_path: public
+  encoding: utf8
+  collation: C
 
 mysql2:
   << : *common
@@ -24,3 +26,5 @@ mysql2:
   port: 3306
   username: root
   password: <%= ENV.fetch("MYSQL_PWD", "password") %>
+  encoding: utf8mb4
+  collation: utf8mb4_bin

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -30,7 +30,7 @@ class Database
 
   def migrate
     ActiveRecord::Migration.verbose = false
-    ActiveRecord::Base.configurations = YAML::load(ERB.new(IO.read("#{dirname}/database.yml")).result)
+    ActiveRecord::Base.configurations = YAML::load(ERB.new(IO.read("#{dirname}/database.yml")).result, aliases: true)
     ActiveRecord::Base.establish_connection ActiveRecord::Base.configurations[adapter]
 
     require "#{dirname}/schema"

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -25,6 +25,7 @@ class Database
     # log.level = Logger::Severity::DEBUG
     log.level = Logger::Severity::UNKNOWN
     ActiveRecord::Base.logger = log
+
     self
   end
 
@@ -48,6 +49,10 @@ class Database
     else
       ActiveRecord::Base.establish_connection config
     end
+
+    ActiveRecord::HashOptions.detect(ActiveRecord::Base.connection, adapter)
+
+    puts "database settings (#{adapter}):", ActiveRecord::HashOptions.settings.inspect
 
     require "#{dirname}/schema"
     require "#{dirname}/models"


### PR DESCRIPTION
fix to build on more recent databases
fix to support more recent versions of rails

remove database checks from tests - they are now known in the system
future: array behavior will mimic those settings
use more basic locales for the database. Otherwise there were too many variations between mac pg, linux pg, mysql, and sqlite

Will still probably need to tweak the locales.
I wanted one that respected ASCII sorting.
Did use binary for mysql, but that did not support `LIKE`.