### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_gem:
+  manageiq-style: ".rubocop_base.yml"
+inherit_from:
+- ".rubocop_local.yml"

--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -1,0 +1,4 @@
+inherit_from:
+- ".rubocop_base.yml"
+- ".rubocop_cc_base.yml"
+- ".rubocop_local.yml"

--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,5 @@
 # git log on this file will show how to generate the gemfiles for this
-%w(6.0.0 6.1.0 7.0 7.1).each do |ar_version|
+%w[6.0.0 6.1.0 7.0 7.1].each do |ar_version|
   appraise "gemfile-#{ar_version.split('.').first(2).join}" do
     gem "activerecord", "~> #{ar_version}"
     remove_gem "byebug"

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ than the pure equality case.
 Active record hash syntax only support equality.
 For things like case insensitivity or regular expression matching, arel is needed.
 
-It would be nice to use `where(:col => val)` syntax for other operators, too.
+It would be nice to use `where(:book_count => gt(22))` like type syntax for more complicated operations, too.
+
+Ranges do provide some operations, so a number of these cases may not be necessary. E.g. `where(:book_count => 5..)`
 
 ### Problem 2
 
-Active record caches data in an association. When a similar association has a where clause, it also needs to be downloaded since the `where()` clause is only executable in the database.
+Active record caches data in an association. When a similar association has a where clause, it also needs to be fetched since the `where()` clause is only executable in the database.
 
 has_many :books
 has_many :overdue_books, -> { where(:overdue => true) }
@@ -25,7 +27,7 @@ It would be nice to only have 1 copy of the data locally.
 
 Active record only supports sorting case sensitive.
 
-It would be nice to use standard `order()`
+It would be nice to use standard `order(insensitive(:name))`
 
 ### Problem 4
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,11 @@
 # ActiveRecord::HashOptions
 
-## Stalled
-
-This is stalled because it is too hard to implement string comparisions that are the same in the database and in sql.
-The solution will probably be simple but needs to be done. Definintely need to use the same locale for ruby as we are using in the database.
-
 ## What is it?
 
 This enhances active record so that it can be used in more cases
 than the pure equality case.
 
-### Equality only
+### Equality only - SOLVED
 
 Active record hash syntax only support equality.
 For things like case insensitivity or regular expression matching, arel is needed.

--- a/activerecord-hash_options.gemspec
+++ b/activerecord-hash_options.gemspec
@@ -1,7 +1,6 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'active_record/hash_options/version'
+
+require_relative 'lib/active_record/hash_options/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "activerecord-hash_options"
@@ -9,22 +8,27 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Keenan Brock"]
   spec.email         = ["keenan@thebrocks.net"]
 
-  spec.summary       = %q{Give ActiveRecord where hashes more power }
-  spec.description   = %q{Gives ActiveRecord where hashes more power like the ability to gt or like}
+  spec.summary       = 'Give ActiveRecord where hashes more power '
+  spec.description   = 'Gives ActiveRecord where hashes more power like the ability to gt or like'
   spec.homepage      = "https://github.com/kbrock/activerecord-hash_options/"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  spec.require_paths = ["lib"]
+  spec.metadata      = {
+    'rubygems_mfa_required' => 'true'
+  }
 
-  # We use appraisal to generate the gemfiles
-  # but other than that, we do not use appraisal during the runtime/development time of gem
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.require_paths = ["lib"]
+  # no real ruby requirements
+  spec.required_ruby_version = ">= 2.6"
+
+  spec.add_development_dependency "activerecord", ">= 5.0"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "erb"
+  spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec-core", "~>3.8.0"
   spec.add_development_dependency "rspec-expectations", "~>3.8.0"
-  spec.add_development_dependency "activerecord", ">= 5.0"
-  spec.add_development_dependency "erb"
+  spec.add_development_dependency "simplecov", ">= 0.21.2"
 end

--- a/activerecord-hash_options.gemspec
+++ b/activerecord-hash_options.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
-  # no real ruby requirements
+
   spec.required_ruby_version = ">= 2.6"
 
   spec.add_development_dependency "activerecord", ">= 5.0"
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "erb"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake", ">= 12.3.3"
-  spec.add_development_dependency "rspec-core", "~>3.8.0"
-  spec.add_development_dependency "rspec-expectations", "~>3.8.0"
+  spec.add_development_dependency "rspec-core", "~>3.8"
+  spec.add_development_dependency "rspec-expectations", "~>3.8"
   spec.add_development_dependency "simplecov", ">= 0.21.2"
 end

--- a/gemfiles/gemfile_60.gemfile
+++ b/gemfiles/gemfile_60.gemfile
@@ -7,4 +7,4 @@ gem "mysql2"
 gem "pg"
 gem "sqlite3", "~> 1.6.9"
 
-gemspec path: "../"
+gemspec :path => "../"

--- a/gemfiles/gemfile_61.gemfile
+++ b/gemfiles/gemfile_61.gemfile
@@ -7,4 +7,4 @@ gem "mysql2"
 gem "pg"
 gem "sqlite3", "~> 1.6.9"
 
-gemspec path: "../"
+gemspec :path => "../"

--- a/gemfiles/gemfile_70.gemfile
+++ b/gemfiles/gemfile_70.gemfile
@@ -7,4 +7,4 @@ gem "mysql2"
 gem "pg"
 gem "sqlite3", "< 2.0"
 
-gemspec path: "../"
+gemspec :path => "../"

--- a/gemfiles/gemfile_71.gemfile
+++ b/gemfiles/gemfile_71.gemfile
@@ -7,4 +7,4 @@ gem "mysql2"
 gem "pg"
 gem "sqlite3", "< 2.0"
 
-gemspec path: "../"
+gemspec :path => "../"

--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "active_record/hash_options/version"
 require "active_record/hash_options/operators"
 require "active_record/hash_options/operators/regexp"
@@ -47,10 +48,12 @@ module ActiveRecord
     end
 
     def self.extended(mod)
+      super
       ActiveRecord::HashOptions.register_my_handler(mod)
     end
 
     def self.inherited(mod)
+      super
       ActiveRecord::HashOptions.register_my_handler(mod)
     end
 
@@ -72,7 +75,7 @@ module ActiveRecord
       end
     end
 
-    def self.filter(scope_or_array, conditions, negate = false)
+    def self.filter(scope_or_array, conditions, negate = false) # rubocop:disable Style/OptionalBooleanParameter
       if scope_or_array.kind_of?(Array)
         filter_array(scope_or_array, conditions, negate)
       else
@@ -125,13 +128,9 @@ module ActiveRecord
         end
       when Array
         if actual_value.nil?
-          if value.include?(nil) # treat as IS NULL
-            true
-          else
-            nil
-          end
+          value.include?(nil) ? true : nil # treat as IS NULL
         else
-          !!value.include?(actual_val)
+          value.include?(actual_val)
         end
       when Range
         if actual_val.nil?
@@ -143,18 +142,12 @@ module ActiveRecord
         value.call(actual_val)
       else # NilClass, String, Integer
         if actual_val.nil?
-          if value.nil? # treat as IS NULL
-            true
-          else
-            nil
-          end
+          value.nil? ? true : nil # treat as IS NULL
         else
           actual_val == value
         end
       end
     end
-
-    private
 
     def self.detect_boolean(clause, connection, collation = nil)
       clause = Arel::Nodes::SqlLiteral.new("#{clause.to_sql} COLLATE #{collation}") if collation
@@ -163,9 +156,11 @@ module ActiveRecord
     rescue NotImplementedError
       false
     end
+    private_class_method :detect_boolean
 
     def self.quote(str)
       Arel::Nodes.build_quoted(str)
     end
+    private_class_method :quote
   end
 end

--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -76,7 +76,7 @@ module ActiveRecord
     end
 
     def self.filter(scope_or_array, conditions, negate = false) # rubocop:disable Style/OptionalBooleanParameter
-      if scope_or_array.kind_of?(Array)
+      if scope_or_array.kind_of?(Array) || scope_or_array.kind_of?(ActiveRecord::HashOptions::Enumerable)
         filter_array(scope_or_array, conditions, negate)
       else
         filter_scope(scope_or_array, conditions, negate)
@@ -127,7 +127,7 @@ module ActiveRecord
           actual_val.match(value)
         end
       when Array
-        if actual_value.nil?
+        if actual_val.nil?
           value.include?(nil) ? true : nil # treat as IS NULL
         else
           value.include?(actual_val)

--- a/lib/active_record/hash_options.rb
+++ b/lib/active_record/hash_options.rb
@@ -94,12 +94,16 @@ module ActiveRecord
     #   false
     #   nil (false for both)
     def self.filter_array(array, conditions, negate)
+      # rails <= 6.0, negation NOR:
+      # method = :all?
+      # rails >= 6.1, negation uses NAND:
+      method = negate ? :any? : :all?
       array.select do |rec|
-        conditions.all? do |name, value|
+        conditions.send(method) do |name, value|
           actual_val = rec.send(name)
           case compare_array_column(actual_val, value)
           when nil # compare with nil is never true
-            false
+            nil
           when false
             negate
           else

--- a/lib/active_record/hash_options/enumerable.rb
+++ b/lib/active_record/hash_options/enumerable.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-# include into any file to add class to make Array#where
 module ActiveRecord
   module HashOptions
+    # Adds where to any class
+    # Most commonly, this is included into Array
+    # Rhe requirement is for the class to implement #select
     module Enumerable
       def where(conditions = :chain)
         if conditions == :chain

--- a/lib/active_record/hash_options/enumerable.rb
+++ b/lib/active_record/hash_options/enumerable.rb
@@ -5,7 +5,7 @@ module ActiveRecord
   module HashOptions
     module Enumerable
       def where(conditions = :chain)
-        if :chain == conditions
+        if conditions == :chain
           ActiveRecord::HashOptions::Enumerable::NotChain.new(self)
         else
           ActiveRecord::HashOptions.filter(self, conditions, false)

--- a/lib/active_record/hash_options/helpers.rb
+++ b/lib/active_record/hash_options/helpers.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module HashOptions
+    # rubocop:disable Style/SingleLineMethods
     module Helpers
       # numeric
       def gt(val); ActiveRecord::HashOptions::GT.new(val); end
@@ -11,12 +13,13 @@ module ActiveRecord
       # string
       def insensitive(val); ActiveRecord::HashOptions::INSENSITIVE.new(val); end
 
-      def starts_with(val) ; ActiveRecord::HashOptions::LIKE.new("#{val}%"); end
-      def ends_with(val) ; ActiveRecord::HashOptions::LIKE.new("%#{val}"); end
-      def contains(val) ; ActiveRecord::HashOptions::LIKE.new("%#{val}%"); end
-      def not_like(val) ; ActiveRecord::HashOptions::NOT_LIKE.new(val); end
+      def starts_with(val); ActiveRecord::HashOptions::LIKE.new("#{val}%"); end
+      def ends_with(val); ActiveRecord::HashOptions::LIKE.new("%#{val}"); end
+      def contains(val); ActiveRecord::HashOptions::LIKE.new("%#{val}%"); end
+      def not_like(val); ActiveRecord::HashOptions::NOT_LIKE.new(val); end
       def like(val); ActiveRecord::HashOptions::LIKE.new(val); end
       def ilike(val); ActiveRecord::HashOptions::ILIKE.new(val); end
     end
+    # rubocop:enable Style/SingleLineMethods
   end
 end

--- a/lib/active_record/hash_options/operators/regexp.rb
+++ b/lib/active_record/hash_options/operators/regexp.rb
@@ -63,7 +63,7 @@ module ActiveRecord
         source.gsub!(/(?<![\\])%%+/, '%')
         # can leave '\.' escaped, but fix []'
         # only suggest a like or equals if we've removed all regular expression stuff
-        source unless source =~ /[\[\]()*{}]/
+        source unless /[\[\]()*{}]/.match?(source)
       end
 
       # if it is simple enough, just use a regular sql like clause. or even an =
@@ -73,7 +73,7 @@ module ActiveRecord
 
         if source.nil?
           ["~", case_sensitive, regex.source]
-        elsif source !~ /([^\\]|^)[%_]/
+        elsif !/([^\\]|^)[%_]/.match?(source)
           ["=", case_sensitive, source]
         else
           ["like", case_sensitive, source]

--- a/lib/active_record/hash_options/operators/regexp.rb
+++ b/lib/active_record/hash_options/operators/regexp.rb
@@ -7,15 +7,15 @@ module ActiveRecord
         proc do |column, op|
           mode, case_sensitive, source = convert_regex(op)
           mode = "like" if mode == "=" && !case_sensitive && ActiveRecord::HashOptions.use_like_for_compare
+          # when sensitive_compare == false, we do not respect case_sensitive for equality
+          # good: we can skip the fn hack. bad: we can never get simple equality working
+          mode = "fn"   if mode == "=" && !case_sensitive && ActiveRecord::HashOptions.sensitive_compare
+
           case mode
           when '='
-            # NOTE: case_sensitive is ignored and always false = false when ActiveRecord::HashOptions.sensitive_compare is false
-            # for this reason, don't use function hack when the db is case insensitive
-            if case_sensitive || !ActiveRecord::HashOptions.sensitive_compare
-              Arel::Nodes::Equality.new(column, Arel::Nodes.build_quoted(source))
-            else
-              Arel::Nodes::Equality.new(Arel::Nodes::NamedFunction.new("LOWER", [column]), Arel::Nodes.build_quoted(source.downcase.delete("\\")))
-            end
+            Arel::Nodes::Equality.new(column, Arel::Nodes.build_quoted(source))
+          when 'fn'
+            Arel::Nodes::Equality.new(Arel::Nodes::NamedFunction.new("LOWER", [column]), Arel::Nodes.build_quoted(source.downcase.delete("\\")))
           when 'like'
             # NOTE: when ActiveRecord::HashOptions.sensitive_like is false, case_sensitive is ignored and basically false
             Arel::Nodes::Matches.new(column, Arel::Nodes.build_quoted(source), nil, case_sensitive)
@@ -25,6 +25,9 @@ module ActiveRecord
         end
       end
 
+      # This responds to where(:col => REGEXP.new(/exp/))
+      # But in truth users would use where(:col => /exp/)
+      # So this is for completeness of interface and isn't really usable
       def call(val)
         val && val =~ expression
       end
@@ -68,6 +71,9 @@ module ActiveRecord
 
       # if it is simple enough, just use a regular sql like clause. or even an =
       def self.convert_regex(regex)
+        # this line is part of the where(:col => REGEXP.new()) interface compatibility:
+        regex = regex.expression if regex.kind_of?(self)
+
         case_sensitive = !(regex.options & Regexp::IGNORECASE > 0) # rubocop:disable Style/InverseMethods
         source = regex_to_like(regex)
 

--- a/lib/active_record/hash_options/version.rb
+++ b/lib/active_record/hash_options/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module HashOptions
     VERSION = "0.1.0"

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -10,8 +10,38 @@ class Table1 < ActiveRecord::Base
   def self.big_name
     where(:name => like("%big%"))
   end
+end
 
-  def self.big_iname
-    where(:name => ilike("%big%"))
+# test inheritance
+class TableC < Table1
+end
+
+# don't do this
+# do Array.send(:include, ActiveRecord::HashOptions::Enumerable)
+# I wanted to not corrupt array so I did this
+class TestArray < Array
+  include ActiveRecord::HashOptions::Enumerable
+
+  def initialize(values)
+    super()
+
+    values.each { |val| self << val }
+  end
+end
+
+class ArbitraryClass
+  include ActiveRecord::HashOptions::Enumerable
+
+  def initialize(values)
+    @array = []
+    values.each { |val| self << val }
+  end
+
+  def <<(value)
+    @array << value
+  end
+
+  def select(&block)
+    @array.select(&block)
   end
 end

--- a/spec/enumerable_spec.rb
+++ b/spec/enumerable_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe ActiveRecord::HashOptions::Enumerable do
+  let(:small) { Table1.new(:name => "small", :value => 1) }
+  let(:big)   { Table1.new(:name => "big", :value => 10) }
+  let(:big2)  { Table1.new(:name => "BIG", :value => 100) }
+  let(:bad)   { Table1.new(:name => nil, :value => nil) }
+
+  let(:array) do
+    ArbitraryClass.new([small, big, big2, bad])
+  end
+
+  let(:arbitrary) do
+    ArbitraryClass.new([small, big, big2, bad])
+  end
+
+  context "with array base class" do
+    describe "#where" do
+      it "filters" do
+        expect(array.where(:name => "big")).to eq([big])
+      end
+
+      it "filters (is null)" do
+        expect(array.where(:name => ["big", nil])).to eq([big, bad])
+      end
+
+      it "negates" do
+        expect(array.where.not(:name => %w[big BIG nil])).to eq([small])
+      end
+    end
+  end
+
+  context "with non AR class" do
+    describe "#where" do
+      it "filters" do
+        expect(arbitrary.where(:name => "big")).to eq([big])
+      end
+
+      it "filters (is null)" do
+        expect(arbitrary.where(:name => ["big", nil])).to eq([big, bad])
+      end
+
+      it "negates" do
+        expect(arbitrary.where.not(:name => %w[big BIG nil])).to eq([small])
+      end
+    end
+  end
+end

--- a/spec/hash_options_spec.rb
+++ b/spec/hash_options_spec.rb
@@ -1,5 +1,3 @@
-Array.send(:include, ActiveRecord::HashOptions::Enumerable)
-
 RSpec.describe ActiveRecord::HashOptions do
   before do
     Table1.destroy_all
@@ -224,7 +222,6 @@ RSpec.describe ActiveRecord::HashOptions do
       expect(filter(collection, {:name => ilike('%small%'), :value => lte(10)}, true)).to eq([big, big2])
     end
   end
-
 
   ############################## Base tests ##############################
 

--- a/spec/hash_options_spec.rb
+++ b/spec/hash_options_spec.rb
@@ -219,8 +219,9 @@ RSpec.describe ActiveRecord::HashOptions do
     end
 
     it "compares with not_compound" do
+      # rails >=6.1 logic:
       # ! (name = small && value >= 100) --> name != small || value > 10
-      expect(filter(collection, {:name => ilike('%small%'), :value => lte(10)}, true)).to eq([big2])
+      expect(filter(collection, {:name => ilike('%small%'), :value => lte(10)}, true)).to eq([big, big2])
     end
   end
 
@@ -272,13 +273,7 @@ RSpec.describe ActiveRecord::HashOptions do
   # this is typically called via:
   #   ActiveRecord::HashOptions.filter(collection, conditions, negate)
   # although there are many ways to reduce the typing - see the readme.
-  def filter(collection, conditions, negate = false)
-    if negate
-      conditions.inject(collection) do |a, (key, value)|
-        a.where.not(key => value)
-      end
-    else
-      collection.where(conditions)
-    end
+  def filter(collection, conditions, negate = false) # rubocop:disable Style/OptionalBooleanParameter
+    ActiveRecord::HashOptions.filter(collection, conditions, negate)
   end
 end

--- a/spec/regexp_spec.rb
+++ b/spec/regexp_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ActiveRecord::HashOptions::REGEXP do
     end
 
     it "detects escaped % (\\%) to equals" do
-      expect(described_class.convert_regex(/^a\%b$/)).to eq(["=", true, "a\\%b"])
+      expect(described_class.convert_regex(/^a\%b$/)).to eq(["=", true, "a\\%b"]) # rubocop:disable Style/RedundantRegexpEscape
     end
 
     it "detects escaped % ([%]) followed by wildcard " do
@@ -80,7 +80,7 @@ RSpec.describe ActiveRecord::HashOptions::REGEXP do
     end
 
     it "detects escaped % ([%]) to equals" do
-      expect(described_class.convert_regex(/^a\%b$/)).to eq(["=", true, "a\\%b"])
+      expect(described_class.convert_regex(/^a\%b$/)).to eq(["=", true, "a\\%b"]) # rubocop:disable Style/RedundantRegexpEscape
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,16 @@
+if ENV['CI']
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter "/spec/"
+    enable_coverage :branch
+    primary_coverage :branch
+  end
+end
+
 require 'bundler/setup'
 require 'active_record'
 require 'active_record/hash_options'
+
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 RSpec.configure do |config|
@@ -21,7 +31,7 @@ RSpec.configure do |config|
     config.default_formatter = "doc"
   end
 
-  # not optimal, but all tests can use the ':column => gt()' syntax
+  # not optimal, but allows tests to use short syntax ':column => gt()'
   config.include ActiveRecord::HashOptions::Helpers
 
   config.profile_examples = ENV["RSPEC_EXAMPLES"].to_i if ENV["RSPEC_EXAMPLES"].to_s.present?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,7 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'bundler/setup'
 require 'active_record'
 require 'active_record/hash_options'
-Dir['./spec/support/**/*.rb'].sort.each {|f| require f}
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -5,6 +5,7 @@ require "erb"
 class Database
   attr_accessor :dirname
   attr_writer :adapter
+
   def initialize
     @dirname = "#{File.dirname(__FILE__)}/../db"
   end
@@ -17,10 +18,11 @@ class Database
 
   def setup
     if defined?(I18n)
-      I18n.enforce_available_locales = false  if I18n.respond_to?(:enforce_available_locales=)
-      #I18n.fallbacks = [I18n.default_locale] if I18n.respond_to?(:fallbacks=)
+      I18n.enforce_available_locales = false if I18n.respond_to?(:enforce_available_locales=)
+      # I18n.fallbacks = [I18n.default_locale] if I18n.respond_to?(:fallbacks=)
     end
-    log = Logger.new(STDERR)
+    log = Logger.new($stderr)
+    # future / developer: may want to introduce an environment variable for help here
     # log = Logger.new('db.log')
     # log.level = Logger::Severity::DEBUG
     log.level = Logger::Severity::UNKNOWN

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -32,16 +32,17 @@ class Database
   def migrate
     ActiveRecord::Migration.verbose = false
 
-    config_contents = ERB.new(IO.read("#{dirname}/database.yml")).result
-    ActiveRecord::Base.configurations = all_config = if YAML.respond_to?(:safe_load)
-      YAML.safe_load(config_contents, aliases: true)
-    else
-      YAML.load(config_contents)
-    end
+    config_contents = ERB.new(File.read("#{dirname}/database.yml")).result
+    ActiveRecord::Base.configurations = all_config =
+      if YAML.respond_to?(:safe_load)
+        YAML.safe_load(config_contents, :aliases => true)
+      else
+        YAML.load(config_contents) # rubocop:disable Security/YAMLLoad
+      end
     config = all_config[adapter]
     if config.blank?
-      $stderr.puts "","","ERROR: Could not find '#{adapter}' in #{filename}"
-      $stderr.puts "Pick from: #{all_config.keys.join(", ")}", "", ""
+      warn "", "", "ERROR: Could not find '#{adapter}' in database.yml"
+      warn "Pick from: #{all_config.keys.join(", ")}", "", ""
       exit(1)
     end
     if ActiveRecord::VERSION::MAJOR >= 6


### PR DESCRIPTION
Hodgepodge fixes:

- Replace `=~` with `match?` (rubocop)
- Fix error when a bad database is specified
- Fix issue on `where.now` - behavior change introduced in rails 6.1
- Fix rubocop issues
- Upgrade rspec
- Tweak readme